### PR TITLE
Fix memory leak for worker fallbehind timers

### DIFF
--- a/lib/worker.js
+++ b/lib/worker.js
@@ -7,6 +7,7 @@
 		this.pid = worker.process.pid;
 		this.id = worker.id;
 		this.startTime = new Date();
+		this.worker = worker;
 
 		this.values = {};
 		this.counters = {};
@@ -174,7 +175,9 @@
 			var diff = process.hrtime(time);
 
 			that.fallBehind = ((diff[0] - 1) * 1e9 + diff[1]) / 1e6;
-			that.measureFallBehind();
+			if (!that.worker.isDead()) {
+				that.measureFallBehind();
+			}
 		}, 1000).unref();
 	};
 


### PR DESCRIPTION
This is a quick fix for a memory leak that I noticed by comparing heapdumps.  If you think a different fix is more appropriate, please feel free to implement something else.

Anyway, when a worker dies, the worker object in the master process never gets garbage collected because the fall-behind timer object still holds a reference to it.  Since the callback to setTimeout calls measureFallBehind() and sets up a new timeout again, the timer is never cleaned up either.

This patch modifies the callback to setTimeout so that it only calls that.measureFallBehind() if the worker isn't dead, preventing the timer from being set up again and allowing the Timer and Worker objects to be garbage collected.